### PR TITLE
Throttle paipu fetches and add fetch state/timer handling to download/convert flow

### DIFF
--- a/main.js
+++ b/main.js
@@ -284,6 +284,8 @@ const ready = () => {
 
     var downloadconvertlist = undefined, downloadconvertresult = undefined;
     var downloadnumber = 0, convertnumber = 0, downloadcount = 0, convertcount = 0;
+    const download_fetch_min_delay = 1000; // ms, avoid burst requests when convert/download failed
+    var downloadfetchtimer = undefined, downloadfetching = false, lastdownloadfetchtime = 0;
 
     function downloadconvertpaipu(){
         let userid = getUserID();
@@ -336,18 +338,32 @@ const ready = () => {
     }
 
     function nextdownloadconvert(){
+        if (downloadfetchtimer != undefined){
+            clearTimeout(downloadfetchtimer);
+            downloadfetchtimer = undefined;
+        }
         if (downloadconvertlist.length == 0){
             //显示转换完成正在组合
             newWindow.webContents.send('downloadconvert', {}, true, downloadconvertresult);
             setTimeout(function () { finaldownloadconvert(); }, 100);
             return;
         }
+        if (downloadfetching) return;
+        let now = Date.now();
+        let wait = Math.max(0, lastdownloadfetchtime + download_fetch_min_delay - now);
+        if (wait > 0){
+            downloadfetchtimer = setTimeout(nextdownloadconvert, wait);
+            return;
+        }
+        downloadfetching = true;
+        lastdownloadfetchtime = Date.now();
         let id = downloadconvertlist[0][0];
         browseWindow.webContents.send('fetchpaipudata', nowgamedata[id].uuid);
         //newWindow.webContents.send('downloadconvert', nowgamedata[id], downloadconvertresult);
     }
 
     function fetchpaipudatacallback(res){
+        downloadfetching = false;
         if (!res) {
             // network error? res is null or undefined.
             res = { error: 'response null/undefined error' };
@@ -442,6 +458,12 @@ const ready = () => {
         });
         downloadconvertresult = undefined;
         downloadconvertlist = undefined;
+        if (downloadfetchtimer != undefined){
+            clearTimeout(downloadfetchtimer);
+            downloadfetchtimer = undefined;
+        }
+        downloadfetching = false;
+        lastdownloadfetchtime = 0;
         if (tempUserID){
             setUserID(tempUserID);
             tempUserID = null;


### PR DESCRIPTION
### Motivation

- Prevent rapid repeated network requests when download/convert fails by introducing a minimum delay between fetches.  
- Avoid concurrent fetches and ensure timers are cleaned up when tasks finish or are aborted.  

### Description

- Introduced `download_fetch_min_delay`, `downloadfetchtimer`, `downloadfetching`, and `lastdownloadfetchtime` to manage fetch throttling and state.  
- Updated `nextdownloadconvert` to clear any pending timer, skip starting a new fetch when one is in progress, and schedule the next fetch with `setTimeout` to enforce the minimum delay based on `lastdownloadfetchtime`.  
- Set `downloadfetching = true` and update `lastdownloadfetchtime` when a fetch is started, and reset `downloadfetching = false` in `fetchpaipudatacallback` when the response arrives.  
- Cleared timers and reset fetch state in the download-completion path to avoid dangling timers or stale state after finishing.  

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b47ef5210832d85692ce276332a92)